### PR TITLE
xgboost 1.5.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -139,8 +139,6 @@ outputs:
         - lib/R/lib
       missing_dso_whitelist:                 # [win]
         - $RPATH/R.dll                       # [win]
-      ignore_run_exports:  # [osx]
-        - llvm-openmp  # [osx]
     requirements:
       build:
         - {{ compiler('m2w64_c') }}          # [win]


### PR DESCRIPTION
This is a rebuild of `xgboost 1.5.1` which removes an unnecessary `ignore_run_exports` for `osx`.

Note that the previous build was merged, but not actually deployed, so the build number was not increased.

Also, `win-64` will be built on a dev instance as before.