### PR TITLE
xgboost 1.5.1 [rebuild for python 3.11/3.12]

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,3 @@
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
-  - "--error-overdepending"
-
-upload_without_merge

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
+
+upload_without_merge

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,4 +7,4 @@ cudatoolkit:
 r_implementation:
   - r-base
   - mro-base  # [not osx and not linux32 and not win32]
-skip_r_bindings: True   # [s390x or ppc64le or aarch64 or osx or win]
+skip_r_bindings: True

--- a/recipe/install-win-wrapper.bat
+++ b/recipe/install-win-wrapper.bat
@@ -7,7 +7,7 @@ set MSYSTEM=MINGW%ARCH%
 set MSYS2_PATH_TYPE=inherit
 set CHERE_INVOKING=1
 
-bash -lc "./install-%PKG_NAME%.sh"
+bash -lc "%SRC_DIR%/install-%PKG_NAME%.sh"
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 exit /b 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 
 build:
   skip: True  # [py<36]
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
 
 build:
   skip: True  # [py<36]
-  number: 1
+  number: 0
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,6 +91,8 @@ outputs:
         - numpy
         - scipy
         - scikit-learn
+        # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
+        - blas=*=openblas  # [osx and x86_64]
     test:
       requires:
         - pip


### PR DESCRIPTION
xgboost 1.5.1

**Destination channel:** defaults

### Links

- [PKG-5221]
- dev_url (pypi): https://github.com/dmlc/xgboost/tree/v1.5.1
- conda-forge: https://github.com/conda-forge/xgboost-feedstock/blob/main/recipe/meta.yaml
- pypi: https://pypi.org/project/xgboost/1.5.1
- pypi inspector: https://inspector.pypi.io/project/xgboost/1.5.1

### Explanation of changes:

- Increment build number
- Upon approval, I'll set abs.yaml to build without merging to master.


[PKG-5221]: https://anaconda.atlassian.net/browse/PKG-5221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ