### PR TITLE
Update build number for _py-xgboost-mutex

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,7 +67,7 @@ outputs:
     version: 2.0
     build:
       string: cpu_0
-      number: 0
+      number: 1
     test:
       commands:
         - echo "Hello py boost!"


### PR DESCRIPTION
Rebuilding again, but correcting a missed build number.
