### PR TITLE
xgboost 2.1.1 fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: a47ca87f3345d2a866cd7ec40933564aa2b7250592d0e9bf613951630fc1fa6f
   patches:
     - patches/0001-remove-dep-nvidia-nccl-cu12.patch
+    - patches/0002-remove-hatch-custom-build-hook.patch
 
 build:
   skip: True  # [py<38]
@@ -79,14 +80,7 @@ outputs:
         - pandas >=1.2
     test:
       requires:
-        # pip 24.2 seems to introduce a check on the tag within the wheel file.
-        # Our WHEEL file has a tag "py3-none-macosx_11_1_arm64" for osx-arm64
-        # but among the platform tags that are checked,
-        # there is no macosx_11_1_arm64 and the pip check fails.
-        # See: https://github.com/pypa/packaging/issues/435
-        # See PR: https://github.com/AnacondaRecipes/xgboost-feedstock/pull/20
-        - pip <24.2  # [osx and arm64]
-        - pip        # [not (osx and arm64)]
+        - pip
         - scikit-learn
       script: test-py-xgboost.py        # [not s390x]
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ outputs:
         - m2-patch  # [win]
       host:
         - python
-        - pip <24.2
+        - pip
         - hatchling >=1.12.1
         - {{ pin_subpackage('libxgboost', exact=True) }}
       run:
@@ -74,12 +74,19 @@ outputs:
         - numpy
         - scipy
           # mkl variant pulls in intel-openmp which conflicts with llvm-openmp. i.e. force to use openblas variant of numpy, scipy, etc.
-        - blas=*=openblas  # [osx and x86_64]
+        - blas =*=openblas  # [osx and x86_64]
       run_constrained:
         - pandas >=1.2
     test:
       requires:
-        - pip <24.2
+        # pip 24.2 seems to introduce a check on the tag within the wheel file.
+        # Our WHEEL file has a tag "py3-none-macosx_11_1_arm64" for osx-arm64
+        # but among the platform tags that are checked,
+        # there is no macosx_11_1_arm64 and the pip check fails.
+        # See: https://github.com/pypa/packaging/issues/435
+        # See PR: https://github.com/AnacondaRecipes/xgboost-feedstock/pull/20
+        - pip <24.2  # [osx and arm64]
+        - pip        # [not (osx and arm64)]
         - scikit-learn
       script: test-py-xgboost.py        # [not s390x]
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,7 +64,7 @@ outputs:
         - m2-patch  # [win]
       host:
         - python
-        - pip
+        - pip <24.2
         - hatchling >=1.12.1
         - {{ pin_subpackage('libxgboost', exact=True) }}
       run:
@@ -79,7 +79,7 @@ outputs:
         - pandas >=1.2
     test:
       requires:
-        - pip
+        - pip <24.2
         - scikit-learn
       script: test-py-xgboost.py        # [not s390x]
       imports:

--- a/recipe/patches/0001-remove-dep-nvidia-nccl-cu12.patch
+++ b/recipe/patches/0001-remove-dep-nvidia-nccl-cu12.patch
@@ -3,8 +3,12 @@ From: Lorenzo Pirritano <lpirritano@anaconda.com>
 Date: Thu, 8 Aug 2024 19:29:05 +0200
 Subject: [PATCH 1/2] remove dep nvidia-nccl-cu12
 
-remove the requirement nvidia-nccl-cu12 because we
-are not building for CUDA.
+remove the requirement nvidia-nccl-cu12 from the metadata
+since we don't ship that package.
+
+nvidia-nccl-cu12 is specific to the python/PyPI ecosystem
+and doesn't map to anything in our ecosystem, at least not
+in this form.
 
 ---
  python-package/pyproject.toml | 1 -

--- a/recipe/patches/0001-remove-dep-nvidia-nccl-cu12.patch
+++ b/recipe/patches/0001-remove-dep-nvidia-nccl-cu12.patch
@@ -1,11 +1,10 @@
 From 8a70efc7fe63b0c563291b6c6f485c351ba41b25 Mon Sep 17 00:00:00 2001
 From: Lorenzo Pirritano <lpirritano@anaconda.com>
 Date: Thu, 8 Aug 2024 19:29:05 +0200
-Subject: [PATCH] remove dep nvidia-nccl-cu12
+Subject: [PATCH 1/2] remove dep nvidia-nccl-cu12
 
-even by renaming the requirement nvidia-nccl-cu12 to nccl
-pip check would fail with:
-"xgboost 2.1.1 requires nccl, which is not installed."
+remove the requirement nvidia-nccl-cu12 because we
+are not building for CUDA.
 
 ---
  python-package/pyproject.toml | 1 -

--- a/recipe/patches/0002-remove-hatch-custom-build-hook.patch
+++ b/recipe/patches/0002-remove-hatch-custom-build-hook.patch
@@ -1,0 +1,35 @@
+From 97d19ad63a020fe55939b9cdb4d63438ebc44b83 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Tue, 13 Aug 2024 18:29:19 +0200
+Subject: [PATCH 2/2] remove hatch custom build hook
+
+pip 24.2 introduces a check on the tag within the wheel file.
+this custom hook creates a tag "py3-none-macosx_11_1_arm64"
+for osx-arm64 but among the platform tags that are checked,
+there is no macosx_11_1_arm64 and the pip check fails.
+
+See: https://github.com/pypa/packaging/issues/435
+See PR: https://github.com/AnacondaRecipes/xgboost-feedstock/pull/20
+
+This patch disables the hatch custom build hook
+
+---
+ python-package/pyproject.toml | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/python-package/pyproject.toml b/python-package/pyproject.toml
+index a470bb2..4ed52a9 100644
+--- a/python-package/pyproject.toml
++++ b/python-package/pyproject.toml
+@@ -44,8 +44,6 @@ datatable = ["datatable"]
+ plotting = ["graphviz", "matplotlib"]
+ pyspark = ["pyspark", "scikit-learn", "cloudpickle"]
+ 
+-[tool.hatch.build.targets.wheel.hooks.custom]
+-
+ [tool.isort]
+ profile = "black"
+ 
+-- 
+2.39.1
+


### PR DESCRIPTION
xgboost 2.1.1 fix

**Destination channel:** defaults

### Links

- [PKG-5352]
- dev_url (pypi): https://github.com/dmlc/xgboost/tree/v2.1.1
- [v2.0.3...v2.1.1](https://github.com/dmlc/xgboost/compare/v2.0.3...v2.1.1) diff: https://github.com/dmlc/xgboost/compare/v2.0.3...v2.1.1
- conda-forge: https://github.com/conda-forge/xgboost-feedstock/blob/main/recipe/meta.yaml
- diff 2.03…2.1.1: https://github.com/conda-forge/xgboost-feedstock/compare/5c1e0fe825acc654cb9c65adad76814446fd11bc...9753ed30fc17610bf34ba475b9d117b6b85bc35f
- pypi: https://pypi.org/project/xgboost/2.1.1
- pypi inspector: https://inspector.pypi.io/project/xgboost/2.1.1

### Explanation of changes:

- fix `pip check`

### Notes for the reviewers

- `pip 24.2` seems to introduce a check on the tag within the wheel file.
- WHEEL content for osx-arm64:
  
  ```
  Wheel-Version: 1.0
  Generator: hatchling 1.21.1
  Root-Is-Purelib: true
  Tag: py3-none-macosx_11_1_arm64
  ```
- compatible tags for the platform: 
  
  ```
  ['macosx_13_0_arm64', 'macosx_13_0_universal2', 'macosx_12_0_arm64', 'macosx_12_0_universal2', 'macosx_11_0_arm64', 'macosx_11_0_universal2', 'macosx_10_16_universal2', 'macosx_10_15_universal2', 'macosx_10_14_universal2', 'macosx_10_13_universal2', 'macosx_10_12_universal2', 'macosx_10_11_universal2', 'macosx_10_10_universal2', 'macosx_10_9_universal2', 'macosx_10_8_universal2', 'macosx_10_7_universal2', 'macosx_10_6_universal2', 'macosx_10_5_universal2', 'macosx_10_4_universal2']
  ```
- there is no `macosx_11_1_arm64` and the `pip check` fails https://github.com/pypa/pip/blob/e98cc5ce078d8c8afd6804ff4e61aa2b12d05715/src/pip/_internal/commands/check.py#L29-L34

### What the internet says

- https://github.com/pypa/packaging/issues/435
- https://github.com/pypa/pip/issues/12884#issuecomment-2261220441

[PKG-5352]: https://anaconda.atlassian.net/browse/PKG-5352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ