### PR TITLE
xgboost 2.0.3 [rebuild: fix custom tag for pip check]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,12 @@ package:
 source:
   url: https://github.com/dmlc/xgboost/releases/download/v{{ version }}/xgboost-{{ version }}.tar.gz
   sha256: 505955b5d770f8217a049beecce79e04a93787371c06dfb4b2414fec9d496bf3
+  patches:
+    - patches/0001-remove-custom-tag.patch
 
 build:
   skip: True  # [py<38]
-  number: 0
+  number: 1
 
 outputs:
   - name: libxgboost

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,8 @@ outputs:
         - cmake
         - ninja-base
         - llvm-openmp  # [osx]
+        - patch               # [not win]
+        - m2-patch            # [win]
       host:
         - llvm-openmp  # [osx]
       run:
@@ -49,6 +51,10 @@ outputs:
       skip: True  # [py<38]
       string: cpu_0
       number: 0
+    requirements:
+      build:
+        - patch               # [not win]
+        - m2-patch            # [win]
     test:
       commands:
         - echo "Hello py boost!"
@@ -59,6 +65,9 @@ outputs:
     build:
       skip: True  # [py<38]
     requirements:
+      build:
+        - patch               # [not win]
+        - m2-patch            # [win]
       host:
         - python
         - pip
@@ -86,6 +95,9 @@ outputs:
     build:
       skip: True  # [py<38]
     requirements:
+      build:
+        - patch               # [not win]
+        - m2-patch            # [win]
       host:
         - python
       run:
@@ -96,6 +108,9 @@ outputs:
     build:
       skip: True  # [py<38]
     requirements:
+      build:
+        - patch               # [not win]
+        - m2-patch            # [win]
       host:
         - python
       run:

--- a/recipe/patches/0001-remove-custom-tag.patch
+++ b/recipe/patches/0001-remove-custom-tag.patch
@@ -1,0 +1,25 @@
+From 7c9a7de09f693bf5ac3acae647c835e15365940b Mon Sep 17 00:00:00 2001
+From: Mohamed Sentissi <msentissi@anaconda.com>
+Date: Wed, 9 Oct 2024 14:29:53 -0400
+Subject: [PATCH] remove custom tag
+
+---
+ pyproject.toml | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 90f127b..d620b0e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -44,8 +44,6 @@ datatable = ["datatable"]
+ plotting = ["graphviz", "matplotlib"]
+ pyspark = ["pyspark", "scikit-learn", "cloudpickle"]
+ 
+-[tool.hatch.build.targets.wheel.hooks.custom]
+-
+ [tool.isort]
+ profile = "black"
+ 
+-- 
+2.45.2
+


### PR DESCRIPTION
xgboost 2.0.3

**Destination channel:** defaults

### Links

- [PKG-5898] 
- [Upstream repository](https://github.com/dmlc/xgboost/tree/v2.0.3)

### Dependency for

- https://github.com/AnacondaRecipes/snowflake-ml-python-feedstock/pull/37

### Explanation of changes:

- In order to use `xgboost 2.0.3` as a dependency for `snowflake-ml-python`, we need to patch out the [custom tag generated in that version](https://github.com/dmlc/xgboost/blob/v2.0.3/python-package/hatch_build.py) because it causes `pip check` to fail with the most recent version of `pip`. This was already [addressed upstream](https://github.com/dmlc/xgboost/blob/master/python-package/hatch_build.py), but it will only be reflected in the next version of xgboost.



[PKG-5898]: https://anaconda.atlassian.net/browse/PKG-5898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ