### PR TITLE
Add CUDA Variants 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -2,6 +2,9 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 # the conda-build parameters to use
+# --error-overdepending removed: CUDA variants add explicit run deps (__cuda,
+# cuda-version, nccl) that aren't detected as linked libs, causing false positives.
+# No other CUDA feedstock uses --error-overdepending.
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,9 +2,6 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
 
 # the conda-build parameters to use
-# --error-overdepending removed: CUDA variants add explicit run deps (__cuda,
-# cuda-version, nccl) that aren't detected as linked libs, causing false positives.
-# No other CUDA feedstock uses --error-overdepending.
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-# the conda-build parameters to use
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"

--- a/recipe/build-libxgboost.bat
+++ b/recipe/build-libxgboost.bat
@@ -1,5 +1,10 @@
 @echo on
 
+set CUDA_ARGS=
+if "%gpu_variant%"=="cuda-13" (
+    set "CUDA_ARGS=-DUSE_CUDA=ON -DUSE_NVTX=ON"
+)
+
 mkdir "%SRC_DIR%"\build
 pushd "%SRC_DIR%"\build
 
@@ -8,6 +13,7 @@ cmake -G "Ninja" ^
     -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
     -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON ^
     -DR_LIB=OFF ^
+    %CUDA_ARGS% ^
     "%SRC_DIR%"
 if errorlevel 1 exit 1
 

--- a/recipe/build-libxgboost.bat
+++ b/recipe/build-libxgboost.bat
@@ -1,7 +1,9 @@
 @echo on
 
 set CUDA_ARGS=
-if "%gpu_variant%"=="cuda-13" (
+REM Use substring match to support future CUDA versions (cuda-13, cuda-14, etc.)
+REM NCCL is not available on Windows, so only USE_CUDA and USE_NVTX are enabled
+if "%gpu_variant:~0,4%"=="cuda" (
     set "CUDA_ARGS=-DUSE_CUDA=ON -DUSE_NVTX=ON"
 )
 

--- a/recipe/build-libxgboost.sh
+++ b/recipe/build-libxgboost.sh
@@ -2,6 +2,12 @@
 
 set -exuo pipefail
 
+# CUDA configuration
+CUDA_ARGS=""
+if [[ "${gpu_variant:-none}" == cuda* ]]; then
+    CUDA_ARGS="-DUSE_CUDA=ON -DUSE_NCCL=ON -DBUILD_WITH_SHARED_NCCL=ON -DUSE_NVTX=ON"
+fi
+
 mkdir -p build-target
 pushd build-target
   cmake ${CMAKE_ARGS} \
@@ -9,6 +15,7 @@ pushd build-target
     -DCMAKE_BUILD_TYPE:STRING="Release" \
     -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON \
     -DCMAKE_INSTALL_PREFIX:PATH="${PREFIX}" \
+    ${CUDA_ARGS} \
     "${SRC_DIR}"
   cmake --build . --target install --config Release
 popd

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
+# Repeated to match gpu_variant zip_keys (none, cuda-13, cuda-13)
 c_compiler:                    # [win]
   - vs2022                     # [win]
   - vs2022                     # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,28 @@
 c_compiler:                    # [win]
   - vs2022                     # [win]
+  - vs2022                     # [win]
+  - vs2022                     # [win]
 cxx_compiler:                  # [win]
   - vs2022                     # [win]
+  - vs2022                     # [win]
+  - vs2022                     # [win]
+
+gpu_variant:
+  - none
+  - cuda-13                    # [linux or win]
+  - cuda-13                    # [linux or win]
+
+cuda_compiler:                 # [linux or win]
+  - cuda-nvcc                  # [linux or win]
+
+cuda_compiler_version:         # [linux or win]
+  - none                       # [linux or win]
+  - 13.0                       # [linux or win]
+  - 13.1                       # [linux or win]
+
+zip_keys:
+  -
+    - gpu_variant
+    - cuda_compiler_version    # [linux or win]
+    - c_compiler               # [win]
+    - cxx_compiler             # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -139,13 +139,6 @@ outputs:
       run:
         - python
         - {{ pin_subpackage('py-xgboost', exact=True) }}
-    test:
-      imports:
-        - xgboost
-      commands:
-        - pip check
-      requires:
-        - pip
 
   - name: xgboost
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ outputs:
       host:
         - llvm-openmp 20.1.8                              # [osx]
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
-        - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda")]
+        - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]
         - cuda-cudart-dev                                  # [(gpu_variant or "").startswith("cuda")]
         - cuda-nvrtc-dev                                   # [(gpu_variant or "").startswith("cuda")]
         - cuda-nvtx-dev                                    # [(gpu_variant or "").startswith("cuda")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - cmake
         - ninja-base
       host:
-        - llvm-openmp 20.1.8                              # [osx]
+        - llvm-openmp                                      # [osx]
         # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); only 13.x variants provided
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
         - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "3.2.0" %}
+{% set build_number = 0 %}
 
 # note: r-xgboost is built from https://github.com/AnacondaRecipes/aggregateR/tree/R-4.3.1/r-xgboost-feedstock
 
@@ -15,7 +16,7 @@ source:
     - patches/0002-remove-hatch-custom-build-hook.patch
 
 build:
-  number: 0
+  number: {{ build_number }}
   skip: True  # [py<310]
 
 requirements:
@@ -30,38 +31,61 @@ outputs:
     script: build-libxgboost.bat  # [win]
     build:
       skip: True  # [py<310]
+      number: {{ build_number + 100 }}  # [(gpu_variant or "").startswith("cuda")]
+      number: {{ build_number }}        # [not (gpu_variant or "").startswith("cuda")]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith("cuda")]
+      string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                  # [not (gpu_variant or "").startswith("cuda")]
+      ignore_run_exports_from:                                # [(gpu_variant or "").startswith("cuda")]
+        - {{ compiler('cuda') }}                              # [(gpu_variant or "").startswith("cuda")]
+      missing_dso_whitelist:              # [(gpu_variant or "").startswith("cuda")]
+        - "**/libcuda.so*"                # [(gpu_variant or "").startswith("cuda")]
+        - "**/nvcuda.dll"                 # [win and (gpu_variant or "").startswith("cuda")]
     requirements:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ compiler('cuda') }}          # [(gpu_variant or "").startswith("cuda")]
         - cmake
         - ninja-base
       host:
-        - llvm-openmp 20.1.8 # [osx]
+        - llvm-openmp 20.1.8                              # [osx]
+        - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
+        - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda")]
+        - cuda-cudart-dev                                  # [(gpu_variant or "").startswith("cuda")]
+        - cuda-nvrtc-dev                                   # [(gpu_variant or "").startswith("cuda")]
+        - cuda-nvtx-dev                                    # [(gpu_variant or "").startswith("cuda")]
+        - nccl                                             # [(gpu_variant or "").startswith("cuda") and linux]
       run:
         - llvm-openmp  # [osx]
         - _openmp_mutex  # [linux]
+        - {{ pin_compatible('cuda-version', min_pin='x') }}  # [(gpu_variant or "").startswith("cuda")]
+        - __cuda                                              # [(gpu_variant or "").startswith("cuda")]
+        - nccl                                                # [(gpu_variant or "").startswith("cuda") and linux]
     test:
       commands:
         - test -f ${PREFIX}/lib/libxgboost${SHLIB_EXT}       # [unix]
         - if not exist %LIBRARY_BIN%\\xgboost.dll exit 1     # [win]
 
-  # Already in the main channel at this version. Commented out to not override the existing package.
-  #- name: _py-xgboost-mutex
-  #  version: 2.0
-  #  build:
-  #    skip: True  # [py<38]
-  #    string: cpu_0
-  #    number: 0
-  #  test:
-  #    commands:
-  #      - echo "Hello py boost!"
+  - name: _py-xgboost-mutex
+    version: 2.0
+    build:
+      skip: True  # [py<310]
+      string: gpu_0  # [(gpu_variant or "").startswith("cuda")]
+      string: cpu_0  # [not (gpu_variant or "").startswith("cuda")]
+      number: 0
+    test:
+      commands:
+        - echo "py-xgboost-mutex"
 
   - name: py-xgboost
     script: build-py-xgboost.sh   # [not win]
     script: build-py-xgboost.bat  # [win]
     build:
       skip: True  # [py<310]
+      number: {{ build_number + 100 }}  # [(gpu_variant or "").startswith("cuda")]
+      number: {{ build_number }}        # [not (gpu_variant or "").startswith("cuda")]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith("cuda")]
+      string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                  # [not (gpu_variant or "").startswith("cuda")]
     requirements:
       host:
         - python
@@ -71,7 +95,7 @@ outputs:
         - {{ pin_subpackage('libxgboost', exact=True) }}
       run:
         - {{ pin_subpackage('libxgboost', exact=True) }}
-        - _py-xgboost-mutex 2.0
+        - {{ pin_subpackage('_py-xgboost-mutex', exact=True) }}
         - python
         - numpy
         - scipy
@@ -91,7 +115,24 @@ outputs:
 
   - name: py-xgboost-cpu
     build:
-      skip: True  # [py<310]
+      skip: True  # [py<310 or (gpu_variant or "").startswith("cuda")]
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('py-xgboost', exact=True) }}
+    test:
+      imports:
+        - xgboost
+      commands:
+        - pip check
+      requires:
+        - pip
+
+  - name: py-xgboost-gpu
+    build:
+      skip: True  # [py<310 or not (gpu_variant or "").startswith("cuda")]
     requirements:
       host:
         - python
@@ -109,6 +150,10 @@ outputs:
   - name: xgboost
     build:
       skip: True  # [py<310]
+      number: {{ build_number + 100 }}  # [(gpu_variant or "").startswith("cuda")]
+      number: {{ build_number }}        # [not (gpu_variant or "").startswith("cuda")]
+      string: cuda{{ cuda_compiler_version | replace('.', '') }}_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith("cuda")]
+      string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                  # [not (gpu_variant or "").startswith("cuda")]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -130,15 +130,15 @@ outputs:
       requires:
         - pip
 
-  - name: py-xgboost-gpu
-    build:
-      skip: True  # [py<310 or not (gpu_variant or "").startswith("cuda")]
-    requirements:
-      host:
-        - python
-      run:
-        - python
-        - {{ pin_subpackage('py-xgboost', exact=True) }}
+  # py-xgboost-gpu meta-package output removed: This was a convenience
+  # meta-package that only depended on py-xgboost (exact pin). PBP test workers
+  # lack the __cuda virtual package (provided by NVIDIA drivers), making
+  # CUDA-only packages untestable. Unlike other outputs which have both CPU/CUDA
+  # variants under the same name (allowing solver fallback to CPU during testing),
+  # py-xgboost-gpu only existed as a CUDA variant with no CPU fallback, so the
+  # PBP dry-run installability check always fails.
+  # Users: install 'xgboost' directly — solver prefers CUDA (build_number+100)
+  # when __cuda is available. Use 'py-xgboost-cpu' for explicit CPU selection.
 
   - name: xgboost
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,9 @@ outputs:
       number: {{ build_number }}        # [not (gpu_variant or "").startswith("cuda")]
       string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [(gpu_variant or "").startswith("cuda")]
       string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}                                                  # [not (gpu_variant or "").startswith("cuda")]
+      # Suppress CUDA compiler run_exports (tight pin); use explicit cuda-version
+      # pin_compatible(min_pin='x') instead for forward compat within major version.
+      # Follows cupy/nccl pattern — see also: nccl (Enhanced Compatibility), ucc, ucx.
       ignore_run_exports_from:                                # [(gpu_variant or "").startswith("cuda")]
         - {{ compiler('cuda') }}                              # [(gpu_variant or "").startswith("cuda")]
       missing_dso_whitelist:              # [(gpu_variant or "").startswith("cuda")]
@@ -48,7 +51,8 @@ outputs:
         - cmake
         - ninja-base
       host:
-        - llvm-openmp 20.1.8                              # [osx]
+        - llvm-openmp {{ cxx_compiler_version }}            # [osx]
+        # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); only 13.x variants provided
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
         - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]
         - cuda-cudart-dev                                  # [(gpu_variant or "").startswith("cuda")]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,7 @@ outputs:
         - cmake
         - ninja-base
       host:
-        - llvm-openmp {{ cxx_compiler_version }}            # [osx]
+        - llvm-openmp 20.1.8                              # [osx]
         # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); only 13.x variants provided
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
         - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "3.2.0" %}
-{% set build_number = 0 %}
+{% set build_number = 1 %}
 
 # note: r-xgboost is built from https://github.com/AnacondaRecipes/aggregateR/tree/R-4.3.1/r-xgboost-feedstock
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,9 +74,9 @@ outputs:
     version: 2.0
     build:
       skip: True  # [py<310]
-      string: gpu_0  # [(gpu_variant or "").startswith("cuda")]
-      string: cpu_0  # [not (gpu_variant or "").startswith("cuda")]
-      number: 0
+      string: gpu_{{ build_number }}  # [(gpu_variant or "").startswith("cuda")]
+      string: cpu_{{ build_number }}  # [not (gpu_variant or "").startswith("cuda")]
+      number: {{ build_number }}
     test:
       commands:
         - echo "py-xgboost-mutex"

--- a/recipe/test-py-xgboost.py
+++ b/recipe/test-py-xgboost.py
@@ -17,7 +17,7 @@ clf = xgboost.XGBClassifier(
     max_depth=2,
     learning_rate=1,
     n_estimators=10,
-    silent=True,
+    verbosity=0,
     objective='multi:softmax',
     seed=5)
 clf.fit(Xtrn, ytrn)


### PR DESCRIPTION
xgboost 3.2.0 add CUDA GPU variants 

**Destination channel:** Defaults

### Links

- [PKG-8496]
- dev_url:        https://github.com/dmlc/xgboost/tree/v3.2.0
- conda_forge:    https://github.com/conda-forge/xgboost-feedstock
- pypi:           https://pypi.org/project/xgboost/3.2.0

### Explanation of changes:

- Add CUDA 13.0 and 13.1 GPU variants (xgboost 3.2.0 requires CUDA compiler >= 12.9)
- NCCL enabled on Linux only; Windows CUDA builds without NCCL

### py-xgboost-gpu output removed

The `py-xgboost-gpu` convenience meta-package (which only depended on `py-xgboost` exact pin) has been intentionally removed. PBP test workers lack the `__cuda` virtual package (provided by NVIDIA GPU drivers), making CUDA-only packages untestable.

**Root cause:** PBP's `test.py` runs a dry-run installability pre-check (`conda create --dry-run <package-name>`) before running `conda-build --test`. For packages like `libxgboost`, `py-xgboost`, and `xgboost` that have both CPU and CUDA variants under the same name, the solver falls back to the CPU variant during the pre-check (then `conda-build --test` tests the specific CUDA `.conda` file, which skips `__cuda` enforcement). However, `py-xgboost-gpu` only existed as a CUDA variant with no CPU fallback, so the dry-run always fails with "nothing provides __cuda".

**User impact:** None. Users should install `xgboost` directly — the solver automatically prefers the CUDA variant (`build_number+100`) when `__cuda` is available on the system, and falls back to CPU otherwise. `py-xgboost-cpu` remains available for explicit CPU selection.

### Notes:

- xgboost 3.2.0 requires `find_package(CUDAToolkit 12.8)` and `CMAKE_CUDA_COMPILER_VERSION >= 12.9`
- CUDA C++ Core Libraries (CCCL) come from the CUDA toolkit packages (`cuda-cccl_*`), no standalone `cccl` package needed
- conda-forge had a CCCL 3.1 compilation issue ([xgboost#11784](https://github.com/dmlc/xgboost/issues/11784)); we avoid this by using toolkit-bundled CCCL

[PKG-8496]: https://anaconda.atlassian.net/browse/PKG-8496