### PR TITLE
Increase xgboost CUDA coverage: 12.9 + 13.0

### DIFF
--- a/recipe/build-libxgboost.bat
+++ b/recipe/build-libxgboost.bat
@@ -1,7 +1,7 @@
 @echo on
 
 set CUDA_ARGS=
-REM Use substring match to support future CUDA versions (cuda-13, cuda-14, etc.)
+REM Use substring match to support any CUDA major version (cuda-12, cuda-13, cuda-14, etc.)
 REM NCCL is not available on Windows, so only USE_CUDA and USE_NVTX are enabled
 if "%gpu_variant:~0,4%"=="cuda" (
     set "CUDA_ARGS=-DUSE_CUDA=ON -DUSE_NVTX=ON"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
-# Repeated to match gpu_variant zip_keys (none, cuda-13, cuda-13)
+# Repeated to match gpu_variant zip_keys (none, cuda-12, cuda-13)
 c_compiler:                    # [win]
   - vs2022                     # [win]
   - vs2022                     # [win]
@@ -10,20 +10,25 @@ cxx_compiler:                  # [win]
 
 gpu_variant:
   - none
-  - cuda-13                    # [linux or win]
+  - cuda-12                    # [linux or win]
   - cuda-13                    # [linux or win]
 
+# Required locally (not just inherited from parent): {{ compiler('cuda') }} reads
+# cuda_compiler from the recipe's effective CBC at metadata-eval time, and without
+# this entry it resolves to the literal "cuda_<platform>" instead of "cuda-nvcc_<platform>".
 cuda_compiler:                 # [linux or win]
   - cuda-nvcc                  # [linux or win]
 
 cuda_compiler_version:         # [linux or win]
   - none                       # [linux or win]
+  - 12.9                       # [linux or win]
   - 13.0                       # [linux or win]
-  - 13.1                       # [linux or win]
 
+# Only zip on linux/win where cuda_compiler_version exists;
+# on osx gpu_variant is always 'none' (single value, no zip needed).
 zip_keys:
-  -
-    - gpu_variant
+  -                            # [linux or win]
+    - gpu_variant              # [linux or win]
     - cuda_compiler_version    # [linux or win]
     - c_compiler               # [win]
     - cxx_compiler             # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "3.2.0" %}
-{% set build_number = 1 %}
+{% set build_number = 3 %}
 
 # note: r-xgboost is built from https://github.com/AnacondaRecipes/aggregateR/tree/R-4.3.1/r-xgboost-feedstock
 
@@ -52,7 +52,7 @@ outputs:
         - ninja-base
       host:
         - llvm-openmp                                      # [osx]
-        # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); only 13.x variants provided
+        # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); 12.9 + 13.0 variants provided
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
         - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]
         - cuda-cudart-dev                                  # [(gpu_variant or "").startswith("cuda")]

--- a/recipe/test-py-xgboost.py
+++ b/recipe/test-py-xgboost.py
@@ -3,6 +3,9 @@ A simple test for xgboost based on scikit-learn.
 
 Note that xgboost's internal tests are NOT shipped with their
 python package on PyPI. Hence our own test is rolled here.
+
+For CUDA-enabled builds, this also exercises device='cuda' since
+PBP CUDA workers have real GPUs.
 """
 import xgboost
 import sklearn.datasets
@@ -13,16 +16,27 @@ X, y = sklearn.datasets.load_iris(return_X_y=True)
 Xtrn, Xtst, ytrn, ytst = sklearn.model_selection.train_test_split(
     X, y, train_size=0.8, random_state=4)
 
-clf = xgboost.XGBClassifier(
-    max_depth=2,
-    learning_rate=1,
-    n_estimators=10,
-    verbosity=0,
-    objective='multi:softmax',
-    seed=5)
-clf.fit(Xtrn, ytrn)
-ypred = clf.predict(Xtst)
-acc = sklearn.metrics.accuracy_score(ytst, ypred)
 
-print('xgboost accuracy on iris:', acc)
-assert acc > 0.9
+def fit_and_score(device):
+    clf = xgboost.XGBClassifier(
+        max_depth=2,
+        learning_rate=1,
+        n_estimators=10,
+        verbosity=0,
+        objective='multi:softmax',
+        device=device,
+        seed=5)
+    clf.fit(Xtrn, ytrn)
+    ypred = clf.predict(Xtst)
+    acc = sklearn.metrics.accuracy_score(ytst, ypred)
+    print('xgboost ({}) accuracy on iris: {}'.format(device, acc))
+    assert acc > 0.9, 'low accuracy on {}: {}'.format(device, acc)
+
+
+fit_and_score('cpu')
+
+build_info = xgboost.build_info()
+print('build_info: USE_CUDA={}, USE_NCCL={}'.format(
+    build_info.get('USE_CUDA'), build_info.get('USE_NCCL')))
+if build_info.get('USE_CUDA'):
+    fit_and_score('cuda')


### PR DESCRIPTION
xgboost 3.2.0: improve CUDA coverage 

**Destination channel:** Defaults

### Links

- [PKG-13207]
- [Upstream repository](https://github.com/dmlc/xgboost/tree/v3.2.0)
- Prior CUDA-variants PR: AnacondaRecipes/xgboost-feedstock#28 (PKG-8496)
- Parent CBC update: AnacondaRecipes/aggregate#449 (cuda_compiler_version 12.9 + 13.0)
- conda-forge: https://github.com/conda-forge/xgboost-feedstock

### Explanation of changes:

- `recipe/conda_build_config.yaml`:
  - Replace `cuda-13`/`13.0` with `cuda-12`/`12.9` in the first variant slot; keep `cuda-13`/`13.0` in the second. Aligns with the aggregate parent CBC pinning (`cuda_compiler_version: 12.9, 13.0` from aggregate#449) and matches peer CUDA feedstocks shipping 12.9 + 13.x..
- `recipe/meta.yaml`: bump `build_number` 1 -> 3.
  - Skipping 2 because `_py-xgboost-mutex-2.0-cpu_2` already exists on `pkgs/main` (built 2024-07-15 in #18, before xgboost's version bump reset its main outputs to 0/1). PBP's default `--skip-existing` would skip it, then conda-build crashes with `FileNotFoundError: _py-xgboost-mutex-2.0-cpu_2.conda`.
  - The existing 3.2.0 main outputs at build 1 are already shipped, so 3 also clears those.
- `recipe/test-py-xgboost.py`: exercise `device='cuda'` for CUDA-enabled builds (gated by `xgboost.build_info()['USE_CUDA']`). PBP CUDA workers have real GPUs, so this verifies the `cuda129_*` / `cuda130_*` builds actually work on hardware, not just that the binary loads.

[PKG-13207]: https://anaconda.atlassian.net/browse/PKG-13207