### PR TITLE
Add explicit openmp usage.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - build

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,13 +1,3 @@
-# Repeated to match gpu_variant zip_keys (none, cuda-12, cuda-13)
-c_compiler:                    # [win]
-  - vs2022                     # [win]
-  - vs2022                     # [win]
-  - vs2022                     # [win]
-cxx_compiler:                  # [win]
-  - vs2022                     # [win]
-  - vs2022                     # [win]
-  - vs2022                     # [win]
-
 gpu_variant:
   - none
   - cuda-12                    # [linux or win]
@@ -23,12 +13,3 @@ cuda_compiler_version:         # [linux or win]
   - none                       # [linux or win]
   - 12.9                       # [linux or win]
   - 13.0                       # [linux or win]
-
-# Only zip on linux/win where cuda_compiler_version exists;
-# on osx gpu_variant is always 'none' (single value, no zip needed).
-zip_keys:
-  -                            # [linux or win]
-    - gpu_variant              # [linux or win]
-    - cuda_compiler_version    # [linux or win]
-    - c_compiler               # [win]
-    - cxx_compiler             # [win]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -13,3 +13,8 @@ cuda_compiler_version:         # [linux or win]
   - none                       # [linux or win]
   - 12.9                       # [linux or win]
   - 13.0                       # [linux or win]
+
+zip_keys:
+  -                            # [linux or win]
+    - gpu_variant              # [linux or win]
+    - cuda_compiler_version    # [linux or win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "xgboost" %}
 {% set version = "3.2.0" %}
-{% set build_number = 3 %}
+{% set build_number = 4 %}
 
 # note: r-xgboost is built from https://github.com/AnacondaRecipes/aggregateR/tree/R-4.3.1/r-xgboost-feedstock
 
@@ -51,7 +51,9 @@ outputs:
         - cmake
         - ninja-base
       host:
+        - libgomp                                          # [linux]
         - llvm-openmp                                      # [osx]
+        - vcomp14                                          # [win and x86_64]
         # xgboost 3.2.0 requires CUDA >= 12.9 (CMakeLists.txt); 12.9 + 13.0 variants provided
         - cuda-version {{ cuda_compiler_version }}         # [(gpu_variant or "").startswith("cuda")]
         - cuda-driver-dev                                  # [(gpu_variant or "").startswith("cuda") and linux]
@@ -61,7 +63,8 @@ outputs:
         - nccl                                             # [(gpu_variant or "").startswith("cuda") and linux]
       run:
         - llvm-openmp  # [osx]
-        - _openmp_mutex  # [linux]
+        - libgomp      # [linux]
+        - vcomp14      # [win and x86_64]
         - {{ pin_compatible('cuda-version', min_pin='x') }}  # [(gpu_variant or "").startswith("cuda")]
         - __cuda                                              # [(gpu_variant or "").startswith("cuda")]
         - nccl                                                # [(gpu_variant or "").startswith("cuda") and linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,10 @@ build:
   skip: True  # [py<310]
 
 requirements:
+  build:
+    - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
+    - {{ compiler('cuda') }}          # [(gpu_variant or "").startswith("cuda")]
   host:
     - python
   run:


### PR DESCRIPTION
xgboost openmp rebuild

**Destination channel:** defaults

### Links

- [PKG-14729](https://anaconda.atlassian.net/browse/PKG-14729) 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Cleanup CBC
- Bump build number
- Add compilers to the top to work around SIR-3252
- Be explicit about openmp implementation that is getting linked 

## Note
Github UI didn't update, the graph is green https://package-build.anaconda.com/v1/graph/f226affe-751b-4bfa-9a22-5288409380c6

[OpenMP usage Audit](https://docs.google.com/spreadsheets/d/1Pln3E1WKlhasfR5NNyT9juhXrcM_63bQpAZRHDjNHtc/edit?usp=sharing)

[PKG-14729]: https://anaconda.atlassian.net/browse/PKG-14729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ